### PR TITLE
Fix include problems

### DIFF
--- a/serverSrc/transport.h
+++ b/serverSrc/transport.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "common.h"
+#include "pthread.h"
 #include "typedefs.h"
 
 // defines error codes that can be returned by transport functions

--- a/serverSrc/typedefs.h
+++ b/serverSrc/typedefs.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "common.h"
+//#include "common.h"
 
 #define MODULE 69
 #define TRANSPORT 99


### PR DESCRIPTION
Having headers include each other only leads to trouble...
I'd recommend against the use of a "common.h" entirely.